### PR TITLE
ネットワークエラー画面を実装

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,40 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.syousa1982.todo4android">
+          package="com.syousa1982.todo4android">
 
     <!-- カメラ機能が必須かどうかを設定 -->
     <uses-feature
-        android:name="android.hardware.camera"
-        android:required="false" />
+            android:name="android.hardware.camera"
+            android:required="false"/>
 
     <!-- インターネットの使用を許可する -->
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET"/>
     <!-- ネットワーク状況の検知を許可する -->
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
-        android:name=".TodoApplication"
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+            android:name=".TodoApplication"
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsRtl="true"
+            android:theme="@style/AppTheme">
 
-        <activity android:name=".view.activity.MainActivity"
-            android:launchMode="singleTop"
-            android:screenOrientation="portrait"
-            android:theme="@style/AppTheme.NoActionBar">
+        <!-- メイン画面 -->
+        <activity
+                android:name=".view.activity.MainActivity"
+                android:launchMode="singleTop"
+                android:screenOrientation="portrait"
+                android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.VIEW"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.DEFAULT" />
-
+                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
 
+        <!-- ネットワークエラー画面 -->
+        <activity
+                android:name=".view.activity.NetworkErrorActivity"
+                android:launchMode="singleTop"
+                android:screenOrientation="portrait"
+                android:theme="@style/AppTheme.NoActionBar"/>
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/syousa1982/todo4android/extension/FragmentExtension.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/extension/FragmentExtension.kt
@@ -1,5 +1,6 @@
 package com.syousa1982.todo4android.extension
 
+import android.app.Activity
 import android.content.Intent
 import android.support.v4.app.Fragment
 import com.syousa1982.todo4android.TodoApplication
@@ -64,3 +65,15 @@ fun Fragment.pop(popCount: Int = 1): Boolean? = baseActivity()?.pop(popCount)
  * @return Boolean 遷移したかどうか
  */
 fun Fragment.pop(resultCode: Int, data: Intent? = null): Boolean? = baseActivity()?.pop(resultCode, data)
+
+/**
+ * FragmentからActivityを閉じる
+ *
+ * @param resultCode 結果値
+ * @param data onActivityResultで受け取る、遷移元へ通知するデータ
+ */
+fun Fragment.finishActivity(resultCode: Int = Activity.RESULT_OK, data: Intent? = null) {
+    val activity = activity ?: return
+    activity.setResult(resultCode, data)
+    activity.finish()
+}

--- a/app/src/main/kotlin/com/syousa1982/todo4android/view/activity/BaseActivity.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/view/activity/BaseActivity.kt
@@ -85,8 +85,14 @@ abstract class BaseActivity : AppCompatActivity(), FragmentController.RootFragme
      */
     open fun onNetworkDisconnected() {
         Log.d(className(), "ネットワークが切断されました")
+        if (this is NetworkErrorActivity) {
+            Log.e(className(), "すでにネットワークエラー画面が開いています")
+            return
+        }
         // Fragmentに通知
         fragmentController.current()?.onNetworkDisconnected()
+        // ネットワークエラー画面を開く
+        startActivityForResult(NetworkErrorActivity.newIntent(this), RequestCode.NETWORK_ERROR.ordinal)
     }
 
     /**

--- a/app/src/main/kotlin/com/syousa1982/todo4android/view/activity/NetworkErrorActivity.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/view/activity/NetworkErrorActivity.kt
@@ -1,0 +1,38 @@
+package com.syousa1982.todo4android.view.activity
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import com.syousa1982.todo4android.R
+import com.syousa1982.todo4android.view.fragment.BaseFragment
+import com.syousa1982.todo4android.view.fragment.NetworkErrorFragment
+
+class NetworkErrorActivity : BaseActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_network_error)
+    }
+
+    override fun onCreateRootFragment(index: Int): BaseFragment {
+        return NetworkErrorFragment.newInstance()
+    }
+
+    override fun onBackPressed() {
+        // バックボタンを許容しない
+        super.moveTaskToBack(true)
+    }
+
+    companion object {
+
+        /**
+         * Intentを生成
+         *
+         * @param context Context
+         * @return Intent
+         */
+        fun newIntent(context: Context): Intent {
+            return Intent(context, NetworkErrorActivity::class.java)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/syousa1982/todo4android/view/fragment/NetworkErrorFragment.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/view/fragment/NetworkErrorFragment.kt
@@ -1,0 +1,65 @@
+package com.syousa1982.todo4android.view.fragment
+
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import com.syousa1982.todo4android.R
+import com.syousa1982.todo4android.databinding.FragmentNetworkErrorBinding
+import com.syousa1982.todo4android.extension.className
+import com.syousa1982.todo4android.extension.finishActivity
+import com.syousa1982.todo4android.extension.pauseClickTimer
+import com.syousa1982.todo4android.helper.NetworkHelper
+
+
+/**
+ * ネットワークエラー画面 Fragment
+ */
+class NetworkErrorFragment : BaseFragment(), View.OnClickListener {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val binding = FragmentNetworkErrorBinding.inflate(inflater, container, false)
+        binding.reloadNetworkButton.setOnClickListener(this)
+        return binding.root
+    }
+
+    override fun onClick(v: View?) {
+        v?.let {
+            it.pauseClickTimer()
+            when (it.id) {
+                R.id.reload_network_button -> checkNetwork()
+            }
+        }
+    }
+
+    /**
+     * ネットワーク更新
+     */
+    private fun checkNetwork() {
+        val activity = activity ?: return
+        if (!NetworkHelper.isConnect(activity)) {
+            Log.e(className(), "ネットワークが確認できません")
+            Toast.makeText(activity, "ネットワークが確認できません", Toast.LENGTH_SHORT).show()
+            return
+        }
+        // ネットワークが確認できたので、エラー画面を閉じる
+        finishActivity(Activity.RESULT_OK)
+    }
+
+    companion object {
+
+        /**
+         * インスタンスを生成
+         *
+         * @return NetworkErrorFragment
+         */
+        fun newInstance(): NetworkErrorFragment {
+            return NetworkErrorFragment()
+        }
+    }
+
+}

--- a/app/src/main/kotlin/com/syousa1982/todo4android/view/fragment/TaskFragment.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/view/fragment/TaskFragment.kt
@@ -76,11 +76,11 @@ class TaskFragment : BaseFragment(), TaskViewable, TaskRecyclerViewAdapter.OnIte
         super.onFragmentResult(requestCode, resultCode, data)
         if (resultCode == RESULT_OK) {
             when (RequestCode.values()[requestCode]) {
-                RequestCode.TASK_ADDED -> {
-                    presenter.fetchTasks()
-                }
-                else -> {
-                    // ignore
+                RequestCode.TASK_ADDED -> presenter.fetchTasks()
+                RequestCode.NETWORK_ERROR -> {
+                    if (!isExistData()) {
+                        presenter.fetchTasks()
+                    }
                 }
             }
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".view.activity.MainActivity">
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:context=".view.activity.MainActivity">
 
     <data>
 
     </data>
 
     <android.support.design.widget.CoordinatorLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
         <android.support.design.widget.AppBarLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
             <android.support.v7.widget.Toolbar
-                android:id="@+id/toolbar"
-                style="@style/AppToolbar" />
+                    android:id="@+id/toolbar"
+                    style="@style/AppToolbar"/>
 
         </android.support.design.widget.AppBarLayout>
 
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1">
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1">
 
                 <FrameLayout
-                    android:id="@+id/container"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent" />
+                        android:id="@+id/container"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"/>
 
             </FrameLayout>
 

--- a/app/src/main/res/layout/activity_network_error.xml
+++ b/app/src/main/res/layout/activity_network_error.xml
@@ -1,0 +1,10 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:context="com.sumashin.view.activity.NetworkErrorActivity">
+
+    <FrameLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+</layout>

--- a/app/src/main/res/layout/fragment_network_error.xml
+++ b/app/src/main/res/layout/fragment_network_error.xml
@@ -1,0 +1,25 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:context="com.sumashin.view.fragment.NetworkErrorFragment">
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical">
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="ネットワークエラーです"/>
+
+        <Button
+                android:id="@+id/reload_network_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="再読み込み"/>
+
+    </LinearLayout>
+
+</layout>


### PR DESCRIPTION
# 概要

WebAPI使ってるので、ネットワークの状態を監視して、ネットワーク切断時のエラーハンドリングをした。

# 実装した機能

- ネットワークの状態を監視
- ネットワークが切れたときにネットワークエラー画面に遷移
- ネットワーク再接続時に再読込ボタンをタップしたときに元の画面に復帰する処理