### PR TITLE
タスクリスト画面のViewModelの実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,9 +87,10 @@ android {
     // Lintオプションを設定
     // "./gradlew test"で実行
     testOptions {
-//        unitTests {
-//            includeAndroidResources = true
-//        }
+        unitTests {
+            includeAndroidResources = true
+            unitTests.returnDefaultValues = true
+        }
         junitPlatform {
             filters {
                 engines {
@@ -176,9 +177,6 @@ dependencies {
     testImplementation "org.xerial:sqlite-jdbc:3.27.2"
 
     // spek
-//    testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
-//    testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
-
     testImplementation('org.jetbrains.spek:spek-api:1.1.5') {
         exclude group: 'org.jetbrains.kotlin'
     }
@@ -187,6 +185,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testImplementation "androidx.arch.core:core-testing:2.0.1"
 
     // spek requires kotlin-reflect, omit when already in classpath
 //    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"

--- a/app/src/main/kotlin/com/syousa1982/todo4android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/di/AppModule.kt
@@ -14,7 +14,7 @@ import org.koin.dsl.module.module
 object AppModule {
     val instance = module {
         // region Presentation Layer
-        viewModel { TaskListViewModel() }
+        viewModel { TaskListViewModel(get()) }
         // endregion
 
         // region Domain Layer

--- a/app/src/main/kotlin/com/syousa1982/todo4android/presentation/tasklist/TaskListViewModel.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/presentation/tasklist/TaskListViewModel.kt
@@ -1,18 +1,21 @@
 package com.syousa1982.todo4android.presentation.tasklist
 
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import com.syousa1982.todo4android.domain.Result
-import com.syousa1982.todo4android.domain.model.Task
 import com.syousa1982.todo4android.domain.model.TaskList
 import com.syousa1982.todo4android.domain.usecase.IToDoUseCase
 import com.syousa1982.todo4android.presentation.BaseViewModel
+import com.syousa1982.todo4android.util.extention.className
+import io.reactivex.rxkotlin.addTo
+import io.reactivex.rxkotlin.subscribeBy
 
 /**
  * タスクリスト一覧 ViewModel
  *
  * @param todoUseCase
  */
-class TaskListViewModel(todoUseCase: IToDoUseCase) : BaseViewModel() {
+class TaskListViewModel(private val todoUseCase: IToDoUseCase) : BaseViewModel() {
 
     val taskLists = MutableLiveData<Result<List<TaskList>>>()
 
@@ -22,19 +25,9 @@ class TaskListViewModel(todoUseCase: IToDoUseCase) : BaseViewModel() {
     }
 
     fun fetchTasks() {
-        taskLists.value = Result.success(
-            listOf(
-                TaskList(1, "ToDo", listOf(
-                    Task(1, "ほげ", Task.Status.DONE),
-                    Task(2, "会社を爆破", Task.Status.TODO),
-                    Task(3, "殺意駆動開発", Task.Status.TODO)
-                )),
-                TaskList(2, "家事", listOf(
-                    Task(1, "飯作る", Task.Status.DONE),
-                    Task(2, "皿洗う", Task.Status.DONE),
-                    Task(3, "掃除", Task.Status.TODO)
-                ))
-            )
-        )
+        todoUseCase.getTaskLists().subscribeBy(
+            onNext = { taskLists.value = it },
+            onError = { e -> Log.e(className(), "エラー発生", e) }
+        ).addTo(disposable)
     }
 }

--- a/app/src/main/kotlin/com/syousa1982/todo4android/presentation/tasklist/TaskListViewModel.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/presentation/tasklist/TaskListViewModel.kt
@@ -16,19 +16,23 @@ class TaskListViewModel : BaseViewModel() {
 
     override fun onResume() {
         super.onResume()
+        fetchTasks()
+    }
+
+    fun fetchTasks() {
         taskLists.value = Result.success(
-                listOf(
-                        TaskList(1, "ToDo", listOf(
-                                Task(1, "ほげ", Task.Status.DONE),
-                                Task(2, "会社を爆破", Task.Status.TODO),
-                                Task(3, "殺意駆動開発", Task.Status.TODO)
-                        )),
-                        TaskList(2, "家事", listOf(
-                                Task(1, "飯作る", Task.Status.DONE),
-                                Task(2, "皿洗う", Task.Status.DONE),
-                                Task(3, "掃除", Task.Status.TODO)
-                        ))
-                )
+            listOf(
+                TaskList(1, "ToDo", listOf(
+                    Task(1, "ほげ", Task.Status.DONE),
+                    Task(2, "会社を爆破", Task.Status.TODO),
+                    Task(3, "殺意駆動開発", Task.Status.TODO)
+                )),
+                TaskList(2, "家事", listOf(
+                    Task(1, "飯作る", Task.Status.DONE),
+                    Task(2, "皿洗う", Task.Status.DONE),
+                    Task(3, "掃除", Task.Status.TODO)
+                ))
+            )
         )
     }
 }

--- a/app/src/main/kotlin/com/syousa1982/todo4android/presentation/tasklist/TaskListViewModel.kt
+++ b/app/src/main/kotlin/com/syousa1982/todo4android/presentation/tasklist/TaskListViewModel.kt
@@ -4,13 +4,15 @@ import androidx.lifecycle.MutableLiveData
 import com.syousa1982.todo4android.domain.Result
 import com.syousa1982.todo4android.domain.model.Task
 import com.syousa1982.todo4android.domain.model.TaskList
+import com.syousa1982.todo4android.domain.usecase.IToDoUseCase
 import com.syousa1982.todo4android.presentation.BaseViewModel
 
 /**
  * タスクリスト一覧 ViewModel
- * todo:usecaseをインジェクション
+ *
+ * @param todoUseCase
  */
-class TaskListViewModel : BaseViewModel() {
+class TaskListViewModel(todoUseCase: IToDoUseCase) : BaseViewModel() {
 
     val taskLists = MutableLiveData<Result<List<TaskList>>>()
 

--- a/app/src/test/kotlin/com/syousa1982/todo4android/data/db/TaskListDaoSpec.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/data/db/TaskListDaoSpec.kt
@@ -11,7 +11,7 @@ import org.dbtools.android.room.jdbc.JdbcSQLiteOpenHelperFactory
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
 import org.junit.platform.runner.JUnitPlatform
 import org.junit.runner.RunWith
 
@@ -24,11 +24,11 @@ class TaskListDaoSpec : Spek({
 
         val database: AppDatabase by lazy {
             Room.inMemoryDatabaseBuilder(
-                    context,
-                    AppDatabase::class.java
+                context,
+                AppDatabase::class.java
             ).allowMainThreadQueries()
-                    .openHelperFactory(JdbcSQLiteOpenHelperFactory())
-                    .build()
+                .openHelperFactory(JdbcSQLiteOpenHelperFactory())
+                .build()
         }
         val result: Single<List<TaskListAndTasks>> by lazy {
             database.taskListDao().loadTaskListAndTasks()
@@ -36,19 +36,19 @@ class TaskListDaoSpec : Spek({
         context("Todoリストにタスク2件追加") {
             val taskList = TaskListEntity(1, "Todoリスト")
             val tasks = listOf(
-                    TaskEntity(1, 1, "hoge", "done"),
-                    TaskEntity(2, 1, "piyo", "todo")
+                TaskEntity(1, 1, "hoge", "done"),
+                TaskEntity(2, 1, "piyo", "todo")
             )
             database.taskListDao().insertTaskLists(taskList).test().await().assertComplete()
             tasks.forEach {
                 database.taskListDao().insertTasks(it).test().await().assertComplete()
             }
-            given("タスクリスト1件存在しているか") {
+            it("タスクリスト1件存在しているか") {
                 result.map {
                     it.count()
                 }.test().await().assertValue(1)
             }
-            given("タスク2件存在しているか") {
+            it("タスク2件存在しているか") {
                 result.map {
                     it.first().tasks.count()
                 }.test().await().assertValue(2)

--- a/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
@@ -4,12 +4,14 @@ import androidx.lifecycle.Observer
 import com.syousa1982.todo4android.domain.Result
 import com.syousa1982.todo4android.domain.model.Task
 import com.syousa1982.todo4android.domain.model.TaskList
+import com.syousa1982.todo4android.domain.usecase.IToDoUseCase
 import com.syousa1982.todo4android.presentation.tasklist.TaskListViewModel
 import com.syousa1982.todo4android.util.extention.useLiveData
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.reactivex.Flowable
 import org.junit.Assert.assertEquals
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -18,32 +20,49 @@ class TaskListViewModelSpec : Spek({
     useLiveData()
     describe("TaskListViewModel") {
         lateinit var observer: Observer<Result<List<TaskList>>>
+        lateinit var todoUseCase: IToDoUseCase
         lateinit var viewModel: TaskListViewModel
         beforeEachTest {
             observer = mockk<Observer<Result<List<TaskList>>>>().also {
                 every { it.onChanged(any()) } just Runs
             }
-            viewModel = TaskListViewModel()
+            todoUseCase = mockk<IToDoUseCase>().also {
+                every { it.getTaskLists() } answers {
+                    Flowable.fromCallable {
+                        Result.success(listOf(
+                            TaskList(1, "todo", listOf(
+                                Task(1, "aaaaa", Task.Status.DONE),
+                                Task(2, "aaaaa", Task.Status.TODO),
+                                Task(3, "aaaaa", Task.Status.TODO)
+                            )),
+                            TaskList(2, "家事", listOf(
+                                Task(1, "飯作る", Task.Status.DONE),
+                                Task(2, "皿洗う", Task.Status.DONE),
+                                Task(3, "掃除", Task.Status.TODO)
+                            ))
+                        ))
+                    }
+                }
+            }
+            viewModel = TaskListViewModel(todoUseCase)
         }
         it("fetchTasks") {
             viewModel.taskLists.observeForever(observer)
             run {
                 viewModel.fetchTasks()
             }
-            val expectValue = Result.success(
-                listOf(
-                    TaskList(1, "ToDo", listOf(
-                        Task(1, "ほげ", Task.Status.DONE),
-                        Task(2, "会社を爆破", Task.Status.TODO),
-                        Task(3, "殺意駆動開発", Task.Status.TODO)
-                    )),
-                    TaskList(2, "家事", listOf(
-                        Task(1, "飯作る", Task.Status.DONE),
-                        Task(2, "皿洗う", Task.Status.DONE),
-                        Task(3, "掃除", Task.Status.TODO)
-                    ))
-                )
-            )
+            val expectValue = Result.success(listOf(
+                TaskList(1, "todo", listOf(
+                    Task(1, "aaaaa", Task.Status.DONE),
+                    Task(2, "aaaaa", Task.Status.TODO),
+                    Task(3, "aaaaa", Task.Status.TODO)
+                )),
+                TaskList(2, "家事", listOf(
+                    Task(1, "飯作る", Task.Status.DONE),
+                    Task(2, "皿洗う", Task.Status.DONE),
+                    Task(3, "掃除", Task.Status.TODO)
+                ))
+            ))
             assertEquals(expectValue, viewModel.taskLists.value)
         }
     }

--- a/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
@@ -10,18 +10,13 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.context
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
-import kotlin.test.assertEquals
+import org.junit.Assert.assertEquals
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-@RunWith(JUnitPlatform::class)
 class TaskListViewModelSpec : Spek({
+    useLiveData()
     describe("TaskListViewModel") {
-        useLiveData()
         lateinit var viewModel: TaskListViewModel
         context("Success") {
             beforeEachTest {

--- a/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
@@ -22,6 +22,18 @@ class TaskListViewModelSpec : Spek({
         lateinit var observer: Observer<Result<List<TaskList>>>
         lateinit var todoUseCase: IToDoUseCase
         lateinit var viewModel: TaskListViewModel
+        val expectValue = Result.success(listOf(
+            TaskList(1, "todo", listOf(
+                Task(1, "aaaaa", Task.Status.DONE),
+                Task(2, "aaaaa", Task.Status.TODO),
+                Task(3, "aaaaa", Task.Status.TODO)
+            )),
+            TaskList(2, "家事", listOf(
+                Task(1, "飯作る", Task.Status.DONE),
+                Task(2, "皿洗う", Task.Status.DONE),
+                Task(3, "掃除", Task.Status.TODO)
+            ))
+        ))
         beforeEachTest {
             observer = mockk<Observer<Result<List<TaskList>>>>().also {
                 every { it.onChanged(any()) } just Runs
@@ -29,18 +41,7 @@ class TaskListViewModelSpec : Spek({
             todoUseCase = mockk<IToDoUseCase>().also {
                 every { it.getTaskLists() } answers {
                     Flowable.fromCallable {
-                        Result.success(listOf(
-                            TaskList(1, "todo", listOf(
-                                Task(1, "aaaaa", Task.Status.DONE),
-                                Task(2, "aaaaa", Task.Status.TODO),
-                                Task(3, "aaaaa", Task.Status.TODO)
-                            )),
-                            TaskList(2, "家事", listOf(
-                                Task(1, "飯作る", Task.Status.DONE),
-                                Task(2, "皿洗う", Task.Status.DONE),
-                                Task(3, "掃除", Task.Status.TODO)
-                            ))
-                        ))
+                        expectValue
                     }
                 }
             }
@@ -51,18 +52,6 @@ class TaskListViewModelSpec : Spek({
             run {
                 viewModel.fetchTasks()
             }
-            val expectValue = Result.success(listOf(
-                TaskList(1, "todo", listOf(
-                    Task(1, "aaaaa", Task.Status.DONE),
-                    Task(2, "aaaaa", Task.Status.TODO),
-                    Task(3, "aaaaa", Task.Status.TODO)
-                )),
-                TaskList(2, "家事", listOf(
-                    Task(1, "飯作る", Task.Status.DONE),
-                    Task(2, "皿洗う", Task.Status.DONE),
-                    Task(3, "掃除", Task.Status.TODO)
-                ))
-            ))
             assertEquals(expectValue, viewModel.taskLists.value)
         }
     }

--- a/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
@@ -17,35 +17,34 @@ import org.spekframework.spek2.style.specification.describe
 class TaskListViewModelSpec : Spek({
     useLiveData()
     describe("TaskListViewModel") {
+        lateinit var observer: Observer<Result<List<TaskList>>>
         lateinit var viewModel: TaskListViewModel
-        context("Success") {
-            beforeEachTest {
-                viewModel = TaskListViewModel()
+        beforeEachTest {
+            observer = mockk<Observer<Result<List<TaskList>>>>().also {
+                every { it.onChanged(any()) } just Runs
             }
-            it("fetchTasks") {
-                val observer = mockk<Observer<Result<List<TaskList>>>> {
-                    every { onChanged(any()) } just Runs
-                }
-                viewModel.taskLists.observeForever(observer)
-                run {
-                    viewModel.fetchTasks()
-                }
-                val expectValue = Result.success(
-                    listOf(
-                        TaskList(1, "ToDo", listOf(
-                            Task(1, "ほげ", Task.Status.DONE),
-                            Task(2, "会社を爆破", Task.Status.TODO),
-                            Task(3, "殺意駆動開発", Task.Status.TODO)
-                        )),
-                        TaskList(2, "家事", listOf(
-                            Task(1, "飯作る", Task.Status.DONE),
-                            Task(2, "皿洗う", Task.Status.DONE),
-                            Task(3, "掃除", Task.Status.TODO)
-                        ))
-                    )
+            viewModel = TaskListViewModel()
+        }
+        it("fetchTasks") {
+            viewModel.taskLists.observeForever(observer)
+            run {
+                viewModel.fetchTasks()
+            }
+            val expectValue = Result.success(
+                listOf(
+                    TaskList(1, "ToDo", listOf(
+                        Task(1, "ほげ", Task.Status.DONE),
+                        Task(2, "会社を爆破", Task.Status.TODO),
+                        Task(3, "殺意駆動開発", Task.Status.TODO)
+                    )),
+                    TaskList(2, "家事", listOf(
+                        Task(1, "飯作る", Task.Status.DONE),
+                        Task(2, "皿洗う", Task.Status.DONE),
+                        Task(3, "掃除", Task.Status.TODO)
+                    ))
                 )
-                assertEquals(expectValue, viewModel.taskLists.value)
-            }
+            )
+            assertEquals(expectValue, viewModel.taskLists.value)
         }
     }
 })

--- a/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
@@ -28,7 +28,7 @@ class TaskListViewModelSpec : Spek({
                 viewModel = TaskListViewModel()
             }
             it("fetchTasks") {
-                val observer = mockk<Observer<Result<List<TaskList>>>>() {
+                val observer = mockk<Observer<Result<List<TaskList>>>> {
                     every { onChanged(any()) } just Runs
                 }
                 viewModel.taskLists.observeForever(observer)

--- a/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/presentation/TaskListViewModelSpec.kt
@@ -1,0 +1,56 @@
+package com.syousa1982.todo4android.presentation
+
+import androidx.lifecycle.Observer
+import com.syousa1982.todo4android.domain.Result
+import com.syousa1982.todo4android.domain.model.Task
+import com.syousa1982.todo4android.domain.model.TaskList
+import com.syousa1982.todo4android.presentation.tasklist.TaskListViewModel
+import com.syousa1982.todo4android.util.extention.useLiveData
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.junit.platform.runner.JUnitPlatform
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(JUnitPlatform::class)
+class TaskListViewModelSpec : Spek({
+    describe("TaskListViewModel") {
+        useLiveData()
+        lateinit var viewModel: TaskListViewModel
+        context("Success") {
+            beforeEachTest {
+                viewModel = TaskListViewModel()
+            }
+            it("fetchTasks") {
+                val observer = mockk<Observer<Result<List<TaskList>>>>() {
+                    every { onChanged(any()) } just Runs
+                }
+                viewModel.taskLists.observeForever(observer)
+                run {
+                    viewModel.fetchTasks()
+                }
+                val expectValue = Result.success(
+                    listOf(
+                        TaskList(1, "ToDo", listOf(
+                            Task(1, "ほげ", Task.Status.DONE),
+                            Task(2, "会社を爆破", Task.Status.TODO),
+                            Task(3, "殺意駆動開発", Task.Status.TODO)
+                        )),
+                        TaskList(2, "家事", listOf(
+                            Task(1, "飯作る", Task.Status.DONE),
+                            Task(2, "皿洗う", Task.Status.DONE),
+                            Task(3, "掃除", Task.Status.TODO)
+                        ))
+                    )
+                )
+                assertEquals(expectValue, viewModel.taskLists.value)
+            }
+        }
+    }
+})

--- a/app/src/test/kotlin/com/syousa1982/todo4android/util/extention/SpekExt.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/util/extention/SpekExt.kt
@@ -2,9 +2,9 @@ package com.syousa1982.todo4android.util.extention
 
 import androidx.arch.core.executor.ArchTaskExecutor
 import androidx.arch.core.executor.TaskExecutor
-import org.jetbrains.spek.api.dsl.SpecBody
+import org.spekframework.spek2.dsl.GroupBody
 
-fun SpecBody.useLiveData() {
+fun GroupBody.useLiveData() {
     beforeEachTest {
         ArchTaskExecutor.getInstance().setDelegate(InstantTaskExecutor)
     }

--- a/app/src/test/kotlin/com/syousa1982/todo4android/util/extention/SpekExt.kt
+++ b/app/src/test/kotlin/com/syousa1982/todo4android/util/extention/SpekExt.kt
@@ -1,0 +1,26 @@
+package com.syousa1982.todo4android.util.extention
+
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+import org.jetbrains.spek.api.dsl.SpecBody
+
+fun SpecBody.useLiveData() {
+    beforeEachTest {
+        ArchTaskExecutor.getInstance().setDelegate(InstantTaskExecutor)
+    }
+    afterEachTest {
+        ArchTaskExecutor.getInstance().setDelegate(null)
+    }
+}
+
+private object InstantTaskExecutor : TaskExecutor() {
+    override fun executeOnDiskIO(runnable: Runnable) {
+        runnable.run()
+    }
+
+    override fun isMainThread(): Boolean = true
+
+    override fun postToMainThread(runnable: Runnable) {
+        runnable.run()
+    }
+}


### PR DESCRIPTION
### Todo

- [x] TaskList#fetchTasks()を検証するテスト
- [x] TaskList#fetchTasks()を検証するテストをUseCase使う前提でリファクタ
- [x] TaskListにUseCaseをインジェクション
- [x] TaskList#fetchTasks()の実装をリファクタ
- [ ] TaskListを追加するメソッドのテスト
- [ ] TaskListを追加するメソッドを実装

### 参考

- https://speakerdeck.com/hkusu/unit-test-for-viewmodel-and-livedata
- https://medium.com/@star_zero/livedata%E3%81%AEunittest-2b295d2818c1
- https://speakerdeck.com/moriiimo/unit-test-with-spek
- https://www.slideshare.net/SaikiIijima/tdd-130994383